### PR TITLE
runescape-launcher: update hash

### DIFF
--- a/pkgs/games/runescape-launcher/default.nix
+++ b/pkgs/games/runescape-launcher/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   # curl https://content.runescape.com/downloads/ubuntu/dists/trusty/non-free/binary-amd64/Packages
   src = fetchurl {
     url = "https://content.runescape.com/downloads/ubuntu/pool/non-free/r/${pname}/${pname}_${version}_amd64.deb";
-    hash = "sha256-rKVHFQ8TR+3o+MTLsLZbyTW7CoprLT2QsTQ3KyAS4b0=";
+    hash = "sha256-4Qh4jrm/l1f7JEvQ6shKH1dMEcvzjhZWGFopAPkNu2Q=";
   };
 
   # What about fhs wrapper?


### PR DESCRIPTION
Hey, it seems runescape has changed hashes again. Here's a patch with the latest one.