### PR TITLE
Resolve jre v17 requirements for pokemmo

### DIFF
--- a/pkgs/games/pokemmo-installer/default.nix
+++ b/pkgs/games/pokemmo-installer/default.nix
@@ -4,18 +4,18 @@
 , makeWrapper
 , coreutils
 , findutils
+, gnome
 , gnugrep
-, jre
+, temurin-jre-bin-17
 , openssl
 , ps
 , wget
 , which
 , xprop
-, zenity
 , libpulseaudio
 }:
-
-stdenv.mkDerivation rec {
+let inherit (gnome) zenity;
+in stdenv.mkDerivation rec {
   pname = "pokemmo-installer";
   version = "1.4.8";
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
         coreutils
         findutils
         gnugrep
-        jre
+        temurin-jre-bin-17
         openssl
         ps
         wget


### PR DESCRIPTION
Hey - apologies if you're not welcome to pull requests, feel free to close this if so.
As of the [15-10-2022 changelog for pokemmo](https://forums.pokemmo.com/index.php?/topic/150494-changelog-15102022-pokemmos-10th-anniversary-part-3/#comment-1946801) the runtime dependency for pokemmo is now JRE v17+
This pull request resolves that with a disappointing caveat that [jre_minimal](https://search.nixos.org/packages?channel=22.05&show=jre_minimal&from=0&size=50&sort=relevance&type=packages&query=jre_minimal) appears unsuitable to utilise despite being a suitable version number and [adoptopenjdk-jre-hotspot-bin-17](https://search.nixos.org/packages?channel=unstable&show=adoptopenjdk-jre-hotspot-bin-17&from=0&size=50&sort=relevance&type=packages&query=adoptopenjdk-jre-hotspot-bin-17) while seeming to be the right choice is currently [shadowing something in all-packages.nix](https://github.com/NixOS/nixpkgs/blob/cfbef7e94f71e7ebd9281918978927555d48db02/pkgs/top-level/aliases.nix#L23)

Because of the above issues, I've proposed the use of `temurin-jre-bin-17` which achieves the requirement of JRE v17+, allows a user to update the software and does not crash on the launch of the updated software. This is only available via unstable unfortunately :disappointed: 

Thanks in advance :grin: !